### PR TITLE
Fix Custom.propTypes

### DIFF
--- a/src/components/Custom.tsx
+++ b/src/components/Custom.tsx
@@ -4,6 +4,7 @@ import { Space } from "./Space";
 import * as PropTypes from "prop-types";
 import { IReactSpaceCommonProps } from "../core-react";
 import { anchoredProps, IAnchorProps } from "./Anchored";
+import { omit } from '../core-utils';
 
 type ICustomProps = Omit<IReactSpaceCommonProps & IAnchorProps, "size"> & {
 	type?: Type;
@@ -22,7 +23,7 @@ type ICustomProps = Omit<IReactSpaceCommonProps & IAnchorProps, "size"> & {
 	resizeTypes?: ResizeType[];
 };
 
-const customProps = {
+const customProps = omit({
 	...anchoredProps,
 	...{
 		type: PropTypes.oneOf([Type.Positioned, Type.Fill, Type.Anchored]),
@@ -38,7 +39,7 @@ const customProps = {
 		height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 		resizeTypes: PropTypes.array,
 	},
-};
+}, 'size');
 
 export const Custom: React.FC<ICustomProps> = ({
 	children,

--- a/src/core-utils.ts
+++ b/src/core-utils.ts
@@ -1,6 +1,17 @@
 import { ISpaceDefinition, SizeUnit, ISize, ResizeHandlePlacement, Type } from "./core-types";
 
-export function shortuuid() {
+export function omit<K extends string, T extends Record<K, unknown>>(object: T, ...keys: K[]): Omit<T, K> {
+	const keySet = new Set<string>(keys)
+	const result = Object.create(null) as Omit<T, K>
+	for (const key in Object.keys(object)) {
+		if (!keySet.has(key)) {
+			result[key] = object[key]
+		}
+	} 
+	return result
+}
+
+export function shortuuid(): string {
 	let firstPart = (Math.random() * 46656) | 0;
 	let secondPart = (Math.random() * 46656) | 0;
 	return ("000" + firstPart.toString(36)).slice(-3) + ("000" + secondPart.toString(36)).slice(-3);

--- a/src/core-utils.ts
+++ b/src/core-utils.ts
@@ -11,7 +11,7 @@ export function omit<K extends string, T extends Record<K, unknown>>(object: T, 
 	return result
 }
 
-export function shortuuid(): string {
+export function shortuuid() {
 	let firstPart = (Math.random() * 46656) | 0;
 	let secondPart = (Math.random() * 46656) | 0;
 	return ("000" + firstPart.toString(36)).slice(-3) + ("000" + secondPart.toString(36)).slice(-3);


### PR DESCRIPTION
Refer to L9 above

```TypeScript
type ICustomProps = Omit<IReactSpaceCommonProps & IAnchorProps, "size"> & {
```

The `customProps` should also drop the `size` prop.