### PR TITLE
Fix omit func in core-utils.ts

### DIFF
--- a/src/core-utils.ts
+++ b/src/core-utils.ts
@@ -1,14 +1,19 @@
 import { ISpaceDefinition, SizeUnit, ISize, ResizeHandlePlacement, Type } from "./core-types";
 
 export function omit<K extends string, T extends Record<K, unknown>>(object: T, ...keys: K[]): Omit<T, K> {
-	const keySet = new Set<string>(keys)
-	const result = Object.create(null) as Omit<T, K>
-	for (const key in Object.keys(object)) {
-		if (!keySet.has(key)) {
-			result[key] = object[key]
+	const keySet = Object.create(null) as Record<K, true>;
+	keys.forEach((key) => {
+		keySet[key] = true;
+	});
+
+	const result = Object.create(null) as Omit<T, K>;
+	Object.keys(object).forEach((key) => {
+		if (!keySet[key]) {
+			result[key] = object[key];
 		}
-	} 
-	return result
+	});
+
+	return result;
 }
 
 export function shortuuid() {


### PR DESCRIPTION
A further fix of #124 , sorry for a bad JS to TS manual-translation.

I previously did a hot fix in the JS file in my node_modules/react-spaces and created the PR with a manual-translation from JS to TS, causing a misspell that `for...in` (should be `for...of`), and now the `<Custom>` component is full broken in prop-type validation. This PR is going to fix it.

Going through your code and found that you prefer the `forEach` to `for...of`, this PR is also made base on `forEach`. I tested it with transpile to JS again in typescript playground and didn't find another break yet.